### PR TITLE
Don't attempt to render title if not present

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -64,7 +64,10 @@ const renderBody = (dom, selectors) => {
 
 
 const renderTitle = (dom) => {
-  document.title = dom.head.querySelector('title').innerText;
+  const titleElement = dom.head.querySelector('title');
+  if (titleElement) {
+    titleElement.innerText;
+  }
 }
 
 


### PR DESCRIPTION
The head stuff is already essentially conditional. And, we have the `inline` feature which already essentially supports the feature we want, I realized. But this will make sure it doesn't crash while trying to load a non-existent title.