### PR TITLE
fireElements on after url changed

### DIFF
--- a/lib/swap.js
+++ b/lib/swap.js
@@ -68,8 +68,8 @@ swap.to = (html, selectors, inline, callback) => {
   renderBody(dom, selectors);
 
   loadAssets(scripts.concat(links, styles), () => {
-    fireElements('on');
     if (callback) callback();
+    fireElements('on');
   });
 
   return swap;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "swap",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swap",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "Server side apps that feel client side.",
   "repository": "git://github.com/shanebo/swap.git",
   "main": "./lib/swap",


### PR DESCRIPTION
We created this PR while attempting to address the concern of elements firing on before a page url changed.

Before this PR, when `fireElements('on')` runs, the events will fire while `location.href` still holds the old page URL.
After this PR, when `fireElements('on')` runs, the events will fire while `location.href` holds the new new page URL.